### PR TITLE
Fix loader export default

### DIFF
--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -64,4 +64,4 @@ const Loader: React.FC = () => {
   );
 };
 
-export default Loader
+export default Loader;


### PR DESCRIPTION
## Summary
- fix typo in Loader export statement

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f44a140988321b1f9f0bfb46b7b6b